### PR TITLE
Adding possibility to add target to route.

### DIFF
--- a/quick-tray-links.php
+++ b/quick-tray-links.php
@@ -35,6 +35,7 @@ class QuickTrayLinksPlugin extends Plugin
             $options = [
                 'icon' => $link['icon'],
                 'route' => $link['link'],
+                'target' => $link['target'],
                 'hint' => isset($link['tooltip']) ? $link['tooltip'] : ''
             ];
             $this->grav['twig']->plugins_quick_tray['QuickTrayLinks-' . $counter++] = $options;


### PR DESCRIPTION
More changes needed to get this to work
- bleuprints.yaml
- quick-tray-links.yml
- README.md

And in the admin plugin change in nav-quicktray.html.twig line 21 add:  target="{{ item.target }}"