### PR TITLE
Added complete functionality for external links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# v1.1.0
+##  01/20/2021
+
+1. [](#new)
+    * Added functionality for external links
+2. [](#improved)
+    * Added german translation
+
 # v1.0.1
 ##  12/02/2020
 

--- a/README.md
+++ b/README.md
@@ -28,9 +28,11 @@ links:
   - icon: fa fa-book
     link: https://learn.getgrav.org
     tooltip: Grav Documentation and Tutorials
+    external: true
   - icon: fa fa-info
     link: /admin/config/info
     tooltip: PHP Information
+    external: true
 ```
 
 Possible fields for each link include:
@@ -38,6 +40,7 @@ Possible fields for each link include:
 * `icon` - icon classes to render icon
 * `link` - Can be a relative URL or an absolute URL
 * `tooltip` - The tooltip to display on hover
+* `external` - Set to true, to open the link in a new window
 * `class` - Any CSS classes you wish to add to the icon link
 * `authorize` - A string that can be use to check authorization
 

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Quick Tray Links
 type: plugin
 slug: quick-tray-links
-version: 1.0.1
+version: 1.1.0
 description: Easily add cusotmizable admin quick tray links
 icon: link
 author:

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -51,3 +51,15 @@ form:
         .tooltip:
           type: textarea
           label: PLUGIN_QUICK_TRAY_LINKS.TOOLTIP
+        
+        .external:
+          type: toggle
+          label: PLUGIN_QUICK_TRAY_LINKS.EXTERNAL.LABEL
+          help: PLUGIN_QUICK_TRAY_LINKS.EXTERNAL.HINT
+          highlight: 1
+          default: 1
+          options:
+              0: PLUGIN_QUICK_TRAY_LINKS.NO
+              1: PLUGIN_QUICK_TRAY_LINKS.YES
+          validate:
+              type: bool

--- a/languages.yaml
+++ b/languages.yaml
@@ -5,6 +5,11 @@ en:
     ICON: 'Icon'
     LINK: 'Link'
     TOOLTIP: 'Tooltip'
+    EXTERNAL: 
+      LABEL: 'External'
+      HINT: 'Opens the link in a new window'
+    YES: 'Yes'
+    NO: 'No'
 
 ru:
   PLUGIN_QUICK_TRAY_LINKS:
@@ -21,3 +26,16 @@ uk:
     ICON: 'Іконка'
     LINK: 'Посилання'
     TOOLTIP: 'Підказка'
+
+de:
+  PLUGIN_QUICK_TRAY_LINKS:
+    LINKS: 'Links'
+    LINKS_HELP: 'Hier definierte Links werden im Quick-Tray angezeigt'
+    ICON: 'Icon'
+    LINK: 'Link'
+    TOOLTIP: 'Tooltip'
+    EXTERNAL: 
+      LABEL: 'Extern'
+      HINT: 'Öffnet den Link in einem neuen Fenster'
+    YES: 'Ja'
+    NO: 'Nein'

--- a/quick-tray-links.php
+++ b/quick-tray-links.php
@@ -37,6 +37,9 @@ class QuickTrayLinksPlugin extends Plugin
                 'route' => $link['link'],
                 'hint' => isset($link['tooltip']) ? $link['tooltip'] : ''
             ];
+            if ($link['external'] == true) {
+                $options['target'] = '_blank';
+            }
             $this->grav['twig']->plugins_quick_tray['QuickTrayLinks-' . $counter++] = $options;
         }
     }

--- a/quick-tray-links.yaml
+++ b/quick-tray-links.yaml
@@ -3,7 +3,8 @@ links:
   - icon: fa fa-book
     link: https://learn.getgrav.org
     tooltip: Grav Documentation and Tutorials
+    external: true
   - icon: fa fa-info
     link: /admin/config/info
     tooltip: PHP Information
-
+    external: true


### PR DESCRIPTION
This PR adds the complete functionality to let Quick-Tray Links be opened in a new window. 

- Each link gets a toggle switch to open the link in a new window (defaults to true)
- Added translations for new functionality in `en`  (`ru` and `uk` are not complete)
- Added complete german translation
- Works without changes to grav admin
- Updated defaults
- Updated readme
- Updated version
- Updated changelog