### PR TITLE
skip empty links, authorization

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -1,7 +1,7 @@
 name: Quick Tray Links
 type: plugin
 slug: quick-tray-links
-version: 1.1.0
+version: 1.1.1
 description: Easily add customizable admin quick tray links
 icon: link
 author:

--- a/quick-tray-links.php
+++ b/quick-tray-links.php
@@ -38,7 +38,9 @@ class QuickTrayLinksPlugin extends Plugin
             $options = [
                 'icon' => $link['icon'],
                 'route' => $link['link'],
-                'hint' => isset($link['tooltip']) ? $link['tooltip'] : ''
+                'hint' => isset($link['tooltip']) ? $link['tooltip'] : '',
+                'authorize' => isset($link['authorize']) ? $link['authorize'] : ''
+
             ];
             if ($link['external'] == true) {
                 $options['target'] = '_blank';

--- a/quick-tray-links.php
+++ b/quick-tray-links.php
@@ -32,6 +32,9 @@ class QuickTrayLinksPlugin extends Plugin
         $counter = 0;
 
         foreach ($this->grav['config']->get('plugins.quick-tray-links.links') as $link) {
+            if ($link == null || $link == false) {
+                continue;
+            }
             $options = [
                 'icon' => $link['icon'],
                 'route' => $link['link'],


### PR DESCRIPTION
I only needed one link in the list, so the default "info" link was merged from the default plugin config as a second link. The easiest solution might be an empty entry in the array in my own config (which will break the processing w/o my plugin changes)

```yaml
links:
  - icon: fa fa-book
    link: /docs
    tooltip: Benutzerhandbuch
    external: true
    authorize: admin.pages
  -
```

Also users, that are not superusers can now enjoy quick links too, if authorize is defined at a link.