### PR TITLE
add access rights configuration to items

### DIFF
--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -63,3 +63,13 @@ form:
               1: PLUGIN_QUICK_TRAY_LINKS.YES
           validate:
               type: bool
+
+        .authorize:
+          type: acl_picker
+          label: PLUGIN_QUICK_TRAY_LINKS.ACCESS.LABEL
+          help: PLUGIN_QUICK_TRAY_LINKS.ACCESS.HINT
+          ignore_empty: true
+          data_type: access
+          validate:
+            type: array
+            value_type: bool

--- a/blueprints.yaml
+++ b/blueprints.yaml
@@ -30,8 +30,8 @@ form:
 
     links:
       type: list
-      label: PLUGIN_QUICK_TRAY_LINKS.LINKS
-      help: PLUGIN_QUICK_TRAY_LINKS.LINKS_HELP
+      label: PLUGIN_QUICK_TRAY_LINKS.LINKS.LABEL
+      help: PLUGIN_QUICK_TRAY_LINKS.LINKS.HINT
 
       fields:
         .icon:

--- a/languages.yaml
+++ b/languages.yaml
@@ -29,6 +29,7 @@ uk:
     ICON: 'Іконка'
     LINK: 'Посилання'
     TOOLTIP: 'Підказка'
+
 fr:
   PLUGIN_QUICK_TRAY_LINKS:
     LINKS: 'Liens'
@@ -36,6 +37,7 @@ fr:
     ICON: 'Icone'
     LINK: 'Lien'
     TOOLTIP: 'Infobulle'
+
 de:
   PLUGIN_QUICK_TRAY_LINKS:
     LINKS: 'Links'

--- a/languages.yaml
+++ b/languages.yaml
@@ -8,6 +8,9 @@ en:
     EXTERNAL:
       LABEL: 'External'
       HINT: 'Opens the link in a new window'
+    ACCESS:
+      LABEL: 'Access'
+      HINT: 'Who can see this link'
     YES: 'Yes'
     NO: 'No'
 
@@ -43,5 +46,8 @@ de:
     EXTERNAL:
       LABEL: 'Extern'
       HINT: 'Öffnet den Link in einem neuen Fenster'
+    ACCESS:
+      LABEL: 'Zugriff'
+      HINT: 'Wer diesen Link sehen kann'
     YES: 'Ja'
     NO: 'Nein'

--- a/languages.yaml
+++ b/languages.yaml
@@ -1,7 +1,8 @@
 en:
   PLUGIN_QUICK_TRAY_LINKS:
-    LINKS: 'Links'
-    LINKS_HELP: 'Links defined here will show up in the navigation quick-tray'
+    LINKS:
+      LABEL: 'Links'
+      HINT: 'Links defined here will show up in the navigation quick-tray'
     ICON: 'Icon'
     LINK: 'Link'
     TOOLTIP: 'Tooltip'
@@ -16,32 +17,36 @@ en:
 
 ru:
   PLUGIN_QUICK_TRAY_LINKS:
-    LINKS: 'Ссылки'
-    LINKS_HELP: 'Определенные здесь ссылки будут отображаться в панели быстрого доступа'
+    LINKS:
+      LABEL: 'Ссылки'
+      HINT: 'Определенные здесь ссылки будут отображаться в панели быстрого доступа'
     ICON: 'Иконка'
     LINK: 'Ссылка'
     TOOLTIP: 'Подсказка'
 
 uk:
   PLUGIN_QUICK_TRAY_LINKS:
-    LINKS: 'Посилання'
-    LINKS_HELP: 'Визначені тут посилання відображатимуться у швидкому лотку навігації'
+    LINKS:
+      LABEL: 'Посилання'
+      HINT: 'Визначені тут посилання відображатимуться у швидкому лотку навігації'
     ICON: 'Іконка'
     LINK: 'Посилання'
     TOOLTIP: 'Підказка'
 
 fr:
   PLUGIN_QUICK_TRAY_LINKS:
-    LINKS: 'Liens'
-    LINKS_HELP: "Les liens ajoutés ici apparaitront dans la barre d'accès rapide du menu"
+    LINKS:
+      LABEL: 'Liens'
+      HINT: "Les liens ajoutés ici apparaitront dans la barre d'accès rapide du menu"
     ICON: 'Icone'
     LINK: 'Lien'
     TOOLTIP: 'Infobulle'
 
 de:
   PLUGIN_QUICK_TRAY_LINKS:
-    LINKS: 'Links'
-    LINKS_HELP: 'Hier definierte Links werden im Quick-Tray angezeigt'
+    LINKS:
+      LABEL: 'Links'
+      HINT: 'Hier definierte Links werden im Quick-Tray angezeigt'
     ICON: 'Icon'
     LINK: 'Link'
     TOOLTIP: 'Tooltip'


### PR DESCRIPTION
This PR adds an option for access configuration to the plugins settings, since the links are only available by default to users with `access.super` permission (#17). These options already were there in the [admin plugin](https://github.com/getgrav/grav-plugin-admin/blob/75f9200a688243b42c645ea389639d45e567f67b/themes/grav/templates/partials/nav-quick-tray.html.twig#L19) for some time, but it wasn't implemented in this plugin yet.

How the configuration can be done:
![image](https://github.com/trilbymedia/grav-plugin-quick-tray-links/assets/73113302/bbcecfa9-d132-4306-af79-ce8b902c395d)

_also some cleanup has been made to the translations, so it has a unified structure._


_closes #17_